### PR TITLE
Add recursive results to liReturn

### DIFF
--- a/src/com/hannonhill/cascade/plugin/assetfactory/AssetFieldsPlugin.java
+++ b/src/com/hannonhill/cascade/plugin/assetfactory/AssetFieldsPlugin.java
@@ -229,7 +229,7 @@ public abstract class AssetFieldsPlugin extends BaseAssetFactoryPlugin
             {
                 if (node.isGroup() && curNode.equals(node.getIdentifier()))
                 {
-                    return searchStructuredData(node.getGroup(), subNodes);
+                    liReturn.addAll(searchStructuredData(node.getGroup(), subNodes));
                 }
             }
         }


### PR DESCRIPTION
Previous recursive call here was returning instead of adding to liReturn.  Any system-data-structure with a group would then return null when the search field was a sibling to any groups.
