### PR TITLE
recursive calls need to collect the results instead of return them

### DIFF
--- a/src/com/hannonhill/cascade/plugin/assetfactory/AssetFieldsPlugin.java
+++ b/src/com/hannonhill/cascade/plugin/assetfactory/AssetFieldsPlugin.java
@@ -6,8 +6,6 @@ import java.util.Date;
 import java.util.Formatter;
 import java.util.List;
 
-import org.apache.log4j.Logger;
-
 import com.cms.assetfactory.BaseAssetFactoryPlugin;
 import com.cms.assetfactory.FatalPluginException;
 import com.cms.assetfactory.PluginException;
@@ -142,7 +140,7 @@ public abstract class AssetFieldsPlugin extends BaseAssetFactoryPlugin
                 Calendar cal = Calendar.getInstance();
                 cal.setTime(reviewDate);
                 Formatter format = new Formatter();
-                String stDate = format.format("%tF", cal).toString();                
+                String stDate = format.format("%tF", cal).toString();
                 format.close();
                 liReturn.add(stDate);
             }
@@ -252,7 +250,7 @@ public abstract class AssetFieldsPlugin extends BaseAssetFactoryPlugin
 	                    if (nodeValues.length > 0 && nodeValues[0] != null && nodeValues[0].trim() != "")
 	                    {
 	                        nodeValue = nodeValues[0];
-	
+
 	                        // for date/time & calendar, return formatted date string, i.e. yyyy-mm-dd
 	                        if (node.getTextNodeOptions().isDatetime())
 	                        {
@@ -266,19 +264,19 @@ public abstract class AssetFieldsPlugin extends BaseAssetFactoryPlugin
 	                        }
 	                        else if (node.getTextNodeOptions().isCalendar())
 	                        {
-	                            
+
 	                            String[] dateParts = nodeValue.split("-");
 	                            int month = Integer.parseInt(dateParts[0]) - 1; // because month is zero-based
 	                            int day = Integer.parseInt(dateParts[1]);
 	                            int year = Integer.parseInt(dateParts[2]);
-	
+
 	                            Calendar cal = Calendar.getInstance();
 	                            cal.set(year, month, day);
 	                            Formatter format = new Formatter();
 	                            String stDate = format.format("%tF", cal).toString();
 	                            format.close();
-	                            liReturn.add(stDate);                            
-	
+	                            liReturn.add(stDate);
+
 	                        }
 	                        // for check-box & multi-select (where multiple values are allowed), concatenate all selected values
 	                        else if (node.getTextNodeOptions().isCheckbox() || node.getTextNodeOptions().isMultiselect())
@@ -289,7 +287,7 @@ public abstract class AssetFieldsPlugin extends BaseAssetFactoryPlugin
 	                                {
 	                                    liReturn.add(nodeValues[i].trim());
 	                                }
-	
+
 	                            }
 	                        }
 	                        else if (!(node.getTextNodeOptions().isWysiwyg()))

--- a/src/com/hannonhill/cascade/plugin/assetfactory/AssetFieldsPlugin.java
+++ b/src/com/hannonhill/cascade/plugin/assetfactory/AssetFieldsPlugin.java
@@ -6,6 +6,8 @@ import java.util.Date;
 import java.util.Formatter;
 import java.util.List;
 
+import org.apache.log4j.Logger;
+
 import com.cms.assetfactory.BaseAssetFactoryPlugin;
 import com.cms.assetfactory.FatalPluginException;
 import com.cms.assetfactory.PluginException;
@@ -229,7 +231,7 @@ public abstract class AssetFieldsPlugin extends BaseAssetFactoryPlugin
             {
                 if (node.isGroup() && curNode.equals(node.getIdentifier()))
                 {
-                    return searchStructuredData(node.getGroup(), subNodes);
+                    liReturn.addAll(searchStructuredData(node.getGroup(), subNodes));
                 }
             }
         }
@@ -239,7 +241,7 @@ public abstract class AssetFieldsPlugin extends BaseAssetFactoryPlugin
             {
                 if (node.isGroup())
                 {
-                    return searchStructuredData(node.getGroup(), sdIdentifier);
+                    liReturn.addAll(searchStructuredData(node.getGroup(), sdIdentifier));
                 }
                 else if (sdIdentifier.equals(node.getIdentifier()) && node.isText())
                 {


### PR DESCRIPTION
otherwise, if a group is found first when searching the node structure it will return results before searching the rest of the node structure, steps to reproduce this bug:
- Setup a page which uses a data definition with a top level element and a group element:

```
<system-data-structure>
    <group identifier="mainMedia" label="Primary Image" collapsed="true">
        <asset type="file" identifier="image" label="Full Size Image"/>
    </group>
    <text type="dropdown" identifier="type" label="Type" required="true">
        <dropdown-item value="article" />
        <dropdown-item value="feature" />
    </text>
    <group identifier="contentSetup" label="Content">
        <text wysiwyg="true" identifier="editor" label="Content"/>
    </group>
</system-data-structure>
```
- Next setup an asset factory for this page and install the `AssetFieldsToFolderStructurePlugin`.
- Set "Asset Field IDs" to  `system-data-structure/type`
- Try and use this asset factory and make sure type is set to "article" and you will get the `INVALID_STRUCTURED_DATA_ERROR` error back in cascade "The following structured data field either does not exist or contains an invalid value: system-data-structure/type".
- Removing the group from the data definition will avoid entry into line 232 and allow the asset factory to complete.
- I've setup an example site for download and testing of this bug and it can be downloaded at: https://dl.dropboxusercontent.com/u/37149395/AssetFieldsPlugin-Bug.csse
